### PR TITLE
only display passed-in prompt

### DIFF
--- a/askpass.go
+++ b/askpass.go
@@ -56,7 +56,7 @@ func askpassOnce(prompt string, out *os.File) (string, error) {
 		defer tty.Close()
 		fd = int(tty.Fd())
 	}
-	out.WriteString(prompt + ": ")
+	out.WriteString(prompt)
 	pw, err := terminal.ReadPassword(fd)
 	out.WriteString("\n")
 	if err != nil {


### PR DESCRIPTION
In the case of git (and maybe others like ssh and sudo), separators like the `:` are passed by the askpass consumer. This resulted in prompts like:

```
Username for audibleblink: : 
```